### PR TITLE
Support `optional` label of proto3

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/mock/mockgen/model"
 	"google.golang.org/protobuf/compiler/protogen"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 type methodType int
@@ -385,6 +386,7 @@ func baseServerStreamMethods() []*model.Method {
 
 func main() {
 	protogen.Options{}.Run(func(plugin *protogen.Plugin) error {
+		plugin.SupportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
 		for path, file := range plugin.FilesByPath {
 			if !file.Generate {
 				continue


### PR DESCRIPTION
Hi @sorcererxw, thank you for the nice tool!

The following error occurs when using the `optional` label for proto3.

```
Warning: plugin "go-grpc-mock" does not support required features.
  Feature "proto3 optional" is required by ** file(s):
```

So, add setting to accept `optional` label.